### PR TITLE
Add support for Matlab

### DIFF
--- a/Readme-mod.txt
+++ b/Readme-mod.txt
@@ -7,7 +7,7 @@ Notable changes:
 * Option to mark all occurrences of a word
 * Word auto-completion
 * Syntax highlighting support for AutoHotkey, AutoIt3, AviSynth, Bash,
-  CMake, CoffeeScript, Inno Setup, LaTeX, Lua, Markdown, NSIS, Ruby, Tcl, YAML and VHDL scripts
+  CMake, CoffeeScript, Inno Setup, LaTeX, Lua, Markdown, MATLAB, NSIS, Ruby, Tcl, YAML and VHDL scripts
 * Improved support for NFO ANSI art
 * Support for replacing Windows Notepad using a clean, unintrusive registry-based method
 * Other various minor changes and tweaks

--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@
 * Option to mark all occurrences of a word
 * Word auto-completion
 * Syntax highlighting support for AutoHotkey, AutoIt3, AviSynth, Bash, CMake, CoffeeScript,
-  Inno Setup, LaTeX, Lua, Markdown, NSIS, Ruby, Tcl, YAML and VHDL scripts
+  Inno Setup, LaTeX, Lua, Markdown, MATLAB, NSIS, Ruby, Tcl, YAML and VHDL scripts
 * Improved support for NFO ANSI art
 * Support for replacing Windows Notepad using a clean, unintrusive registry-based method
 * Other various minor changes and tweaks

--- a/lexlink.js
+++ b/lexlink.js
@@ -22,6 +22,7 @@
     "lmLua",
     "lmMake",
     "lmMarkdown",
+    "lmMatlab",
     "lmNsis",
     "lmNull",
     "lmPascal",

--- a/scintilla/Scintilla.vcxproj
+++ b/scintilla/Scintilla.vcxproj
@@ -153,6 +153,7 @@
     <ClCompile Include="lexers\LexLua.cxx" />
     <ClCompile Include="lexers\LexMake.cxx" />
     <ClCompile Include="lexers\LexMarkdown.cxx" />
+    <ClCompile Include="lexers\LexMatlab.cxx" />
     <ClCompile Include="lexers\LexNsis.cxx" />
     <ClCompile Include="lexers\LexNull.cxx" />
     <ClCompile Include="lexers\LexPascal.cxx" />

--- a/scintilla/Scintilla.vcxproj.filters
+++ b/scintilla/Scintilla.vcxproj.filters
@@ -75,6 +75,9 @@
     <ClCompile Include="lexers\LexMarkdown.cxx">
       <Filter>lexers</Filter>
     </ClCompile>
+    <ClCompile Include="lexers\LexMatlab.cxx">
+      <Filter>lexers</Filter>
+    </ClCompile>
     <ClCompile Include="lexers\LexNsis.cxx">
       <Filter>lexers</Filter>
     </ClCompile>

--- a/scintilla/src/Catalogue.cxx
+++ b/scintilla/src/Catalogue.cxx
@@ -136,7 +136,7 @@ int Scintilla_LinkLexers() {
 	//LINK_LEXER(lmMagikSF);
 	LINK_LEXER(lmMake);
 	LINK_LEXER(lmMarkdown);
-	//LINK_LEXER(lmMatlab);
+	LINK_LEXER(lmMatlab);
 	//LINK_LEXER(lmMETAPOST);
 	//LINK_LEXER(lmMMIXAL);
 	//LINK_LEXER(lmModula);

--- a/src/Notepad2.c
+++ b/src/Notepad2.c
@@ -3437,6 +3437,7 @@ LRESULT MsgCommand(HWND hwnd,WPARAM wParam,LPARAM lParam)
           EndWaitCursor();
           break;
         case SCLEX_LATEX:
+        case SCLEX_MATLAB:
           BeginWaitCursor();
           EditToggleLineComments(hwndEdit,L"%",TRUE);
           EndWaitCursor();
@@ -3488,6 +3489,9 @@ LRESULT MsgCommand(HWND hwnd,WPARAM wParam,LPARAM lParam)
           break;
         case SCLEX_COFFEESCRIPT:
           EditEncloseSelection(hwndEdit,L"###",L"###");
+          break;
+        case SCLEX_MATLAB:
+          EditEncloseSelection(hwndEdit,L"%{",L"%}");
       }
       break;
 
@@ -6248,7 +6252,7 @@ void ParseCommandLine()
             LocalFree(lpSchemeArg);
             lpSchemeArg = NULL;
           }
-          iInitialLexer = 34;
+          iInitialLexer = 35;
           flagLexerSpecified = 1;
           break;
 
@@ -6257,7 +6261,7 @@ void ParseCommandLine()
             LocalFree(lpSchemeArg);
             lpSchemeArg = NULL;
           }
-          iInitialLexer = 35;
+          iInitialLexer = 36;
           flagLexerSpecified = 1;
           break;
 

--- a/src/Styles.c
+++ b/src/Styles.c
@@ -2459,6 +2459,7 @@ EDITLEXER lexYAML = { SCLEX_YAML, 63355, L"YAML", L"yaml; yml", L"", &KeyWords_Y
                       { SCE_YAML_OPERATOR, 63132, L"Operator", L"fore:#333366", L"" },
                       { -1, 00000, L"", L"", L"" } } };
 
+
 KEYWORDLIST KeyWords_VHDL = {
 "access after alias all architecture array assert attribute begin block body buffer bus case component configuration "
 "constant disconnect downto else elsif end entity exit file for function generate generic group guarded if impure in "
@@ -2515,6 +2516,26 @@ EDITLEXER lexCOFFEESCRIPT = { SCLEX_COFFEESCRIPT, 63362, L"Coffeescript", L"coff
                        { -1, 00000, L"", L"", L"" } } };
 
 
+KEYWORDLIST KeyWords_MATLAB = {
+"break case catch continue else elseif end for function global if otherwise "
+"persistent return switch try while",
+"", "", "", "", "", "", "", "" };
+
+
+EDITLEXER lexMATLAB = { SCLEX_MATLAB, 63360, L"MATLAB", L"matlab", L"", &KeyWords_MATLAB, {
+                        { STYLE_DEFAULT, 63126, L"Default", L"", L"" },
+                        //{ SCE_MATLAB_DEFAULT, L"Default", L"", L"" },
+                        { SCE_MATLAB_COMMENT, 63127, L"Comment", L"fore:#008000", L"" },
+                        { SCE_MATLAB_COMMAND, 63236, L"Command", L"bold", L"" },
+                        { SCE_MATLAB_NUMBER, 63130, L"Number", L"fore:#FF8000", L"" },
+                        { SCE_MATLAB_KEYWORD, 63128, L"Keyword", L"fore:#00007F; bold", L"" },
+                        { MULTI_STYLE(SCE_MATLAB_STRING,SCE_MATLAB_DOUBLEQUOTESTRING,0,0), 63131, L"String", L"fore:#7F007F", L"" },
+                        { SCE_MATLAB_OPERATOR, 63132, L"Operator", L"", L"" },
+                        { SCE_MATLAB_IDENTIFIER, 63129, L"Identifier", L"", L"" },
+                        { -1, 00000, L"", L"", L"" } } };
+
+
+
 // This array holds all the lexers...
 // Don't forget to change the number of the lexer for HTML and XML
 // in Notepad2.c ParseCommandLine() if you change this array!
@@ -2540,6 +2561,7 @@ PEDITLEXER pLexArray[NUMLEXERS] =
   &lexJS,
   &lexMAK,
   &lexMARKDOWN,
+  &lexMATLAB,
   &lexLATEX,
   &lexLUA,
   &lexNSIS,

--- a/src/Styles.h
+++ b/src/Styles.h
@@ -55,7 +55,7 @@ typedef struct _editlexer
 
 
 // Number of Lexers in pLexArray
-#define NUMLEXERS 38
+#define NUMLEXERS 39
 
 
 void   Style_Load();


### PR DESCRIPTION
This fixes #28.

TODO:
- [ ] Stream comment should add a new line but take into account the current line endings `%{comment%}`
- [ ] Associate `.m` files to open with matlab lexer instead of the C/C++ one
