### PR TITLE
Add check for VS2013 update 1.

### DIFF
--- a/src/Version.h
+++ b/src/Version.h
@@ -76,7 +76,11 @@
 #elif defined(_MSC_VER)
     #if _MSC_VER == 1800
         #if (_MSC_FULL_VER >= 180021005)
-            #define VERSION_COMPILER    L"MSVC 2013"
+            #if (_MSC_BUILD > 0)
+                #define VERSION_COMPILER    L"MSVC 2013 Update " STRINGIFY(_MSC_BUILD)
+            #else
+                #define VERSION_COMPILER    L"MSVC 2013"
+            #endif
         #elif (_MSC_FULL_VER < 180021005)
             #define VERSION_COMPILER    L"MSVC 2013 Preview/Beta/RC"
         #endif


### PR DESCRIPTION
The compiler version hasn't changed, so it's necessary to check _MSC_BUILD.
