### PR TITLE
To send font name as UTF-8 (Scintilla 3.5.3 was changed)

### DIFF
--- a/FontUTF8
+++ b/FontUTF8
@@ -1,0 +1,1 @@
+Patch to work with font interpretation of Scintilla 3.5.3.

--- a/FontUTF8
+++ b/FontUTF8
@@ -1,1 +1,0 @@
-Patch to work with font interpretation of Scintilla 3.5.3.

--- a/src/Styles.c
+++ b/src/Styles.c
@@ -4031,7 +4031,7 @@ void Style_SetStyles(HWND hwnd,int iStyle,LPCWSTR lpszStyle)
   // Font
   if (Style_StrGetFont(lpszStyle,tch,COUNTOF(tch))) {
     char mch[256];
-    WideCharToMultiByte(CP_ACP,0,tch,-1,mch,COUNTOF(mch),NULL,NULL);
+    WideCharToMultiByte(CP_UTF8,0,tch,-1,mch,COUNTOF(mch),NULL,NULL);
     SendMessage(hwnd,SCI_STYLESETFONT,iStyle,(LPARAM)mch);
   }
 


### PR DESCRIPTION
Patch to send font names in UTF-8 (Scintilla 3.5.3 was changed).
In prior versions of Scintilla, font names are sent as ANSI.