### PR TITLE
To send font names in UTF-8

### DIFF
--- a/src/Styles.c
+++ b/src/Styles.c
@@ -4031,7 +4031,7 @@ void Style_SetStyles(HWND hwnd,int iStyle,LPCWSTR lpszStyle)
   // Font
   if (Style_StrGetFont(lpszStyle,tch,COUNTOF(tch))) {
     char mch[256];
-    WideCharToMultiByte(CP_ACP,0,tch,-1,mch,COUNTOF(mch),NULL,NULL);
+    WideCharToMultiByte(CP_UTF8,0,tch,-1,mch,COUNTOF(mch),NULL,NULL);
     SendMessage(hwnd,SCI_STYLESETFONT,iStyle,(LPARAM)mch);
   }
 


### PR DESCRIPTION
Scintilla 3.5.3 interpret font names in UTF-8.
In previous versions, font names were sent in ANSI.

So, Styles.c should be patched to send font names in UTF-8.