### PR TITLE
Show line highlighting always

### DIFF
--- a/src/Styles.c
+++ b/src/Styles.c
@@ -2921,6 +2921,7 @@ void Style_SetLexer(HWND hwnd,PEDITLEXER pLexNew)
     if (Style_StrGetColor(FALSE,lexDefault.Styles[8+iIdx].szValue,&rgb)) // caret line back
     {
       SendMessage(hwnd,SCI_SETCARETLINEVISIBLE,TRUE,0);
+      SendMessage(hwnd,SCI_SETCARETLINEVISIBLEALWAYS,TRUE,0);
       SendMessage(hwnd,SCI_SETCARETLINEBACK,rgb,0);
 
       if (Style_StrGetAlpha(lexDefault.Styles[8+iIdx].szValue,&iValue))
@@ -3196,6 +3197,7 @@ void Style_SetCurrentLineBackground(HWND hwnd)
     if (Style_StrGetColor(FALSE,lexDefault.Styles[8+iIdx].szValue,&rgb)) // caret line back
     {
       SendMessage(hwnd,SCI_SETCARETLINEVISIBLE,TRUE,0);
+      SendMessage(hwnd,SCI_SETCARETLINEVISIBLEALWAYS,TRUE,0);
       SendMessage(hwnd,SCI_SETCARETLINEBACK,rgb,0);
 
       if (Style_StrGetAlpha(lexDefault.Styles[8+iIdx].szValue,&iValue))


### PR DESCRIPTION
Show line highligting even if editor window does not have the focus.

This is a quickfix.
I can build a version with extended menu switching support for highlighting "off", "when focused" or "always", if you would prefer this solution...