### PR TITLE
using SC_TECHNOLOGY_DIRECTWRITE rather than SC_TECHNOLOGY_DEFAULT

### DIFF
--- a/src/Notepad2.c
+++ b/src/Notepad2.c
@@ -672,6 +672,8 @@ int WINAPI WinMain(HINSTANCE hInstance,HINSTANCE hPrevInst,LPSTR lpCmdLine,int n
   if (!(hwnd = InitInstance(hInstance,lpCmdLine,nCmdShow)))
     return FALSE;
 
+  SciCall_SetTechnology(SC_TECHNOLOGY_DIRECTWRITE);
+
   hAccMain = LoadAccelerators(hInstance,MAKEINTRESOURCE(IDR_MAINWND));
   hAccFindReplace = LoadAccelerators(hInstance,MAKEINTRESOURCE(IDR_ACCFINDREPLACE));
 
@@ -3657,9 +3659,9 @@ LRESULT MsgCommand(HWND hwnd,WPARAM wParam,LPARAM lParam)
         }
         else
         {
-            // define (behöver bara göra detta en gång egentligen)
-            //SendMessage( hwndEdit , SCI_MARKERSETBACK , 0 , 74 | (203 << 8) | (0 << 16) ); //behöver bara göra detta en gång egentligen
-            //SendMessage( hwndEdit , SCI_MARKERDEFINE , 0 , SC_MARK_ARROWS );    //behöver bara göra detta en gång egentligen
+            // define (behÃ¶ver bara gÃ¶ra detta en gÃ¥ng egentligen)
+            //SendMessage( hwndEdit , SCI_MARKERSETBACK , 0 , 74 | (203 << 8) | (0 << 16) ); //behÃ¶ver bara gÃ¶ra detta en gÃ¥ng egentligen
+            //SendMessage( hwndEdit , SCI_MARKERDEFINE , 0 , SC_MARK_ARROWS );    //behÃ¶ver bara gÃ¶ra detta en gÃ¥ng egentligen
 
             if( bShowSelectionMargin )
             {
@@ -3673,8 +3675,8 @@ LRESULT MsgCommand(HWND hwnd,WPARAM wParam,LPARAM lParam)
             }
 
 
-            //SendMessage( hwndEdit , SCI_MARKERSETBACK , 0 , 180 | (255 << 8) | (180 << 16) ); //behöver bara göra detta en gång egentligen
-            //SendMessage( hwndEdit , SCI_MARKERDEFINE , 0 , SC_MARK_BACKGROUND );    //behöver bara göra detta en gång egentligen
+            //SendMessage( hwndEdit , SCI_MARKERSETBACK , 0 , 180 | (255 << 8) | (180 << 16) ); //behÃ¶ver bara gÃ¶ra detta en gÃ¥ng egentligen
+            //SendMessage( hwndEdit , SCI_MARKERDEFINE , 0 , SC_MARK_BACKGROUND );    //behÃ¶ver bara gÃ¶ra detta en gÃ¥ng egentligen
 
             // set
             SendMessage( hwndEdit , SCI_MARKERADD , iLine , 0 );

--- a/src/SciCall.h
+++ b/src/SciCall.h
@@ -145,3 +145,11 @@ DeclareSciCallV1(EnsureVisible, ENSUREVISIBLE, int, line);
 //
 //
 DeclareSciCallV2(SetProperty, SETPROPERTY, const char *, key, const char *, value);
+
+
+//=============================================================================
+//
+//  SetTechnology
+//
+//
+DeclareSciCallV1(SetTechnology, SETTECHNOLOGY, int, technology);


### PR DESCRIPTION
SC_TECHNOLOGY_DIRECTWRITE performs better font linking than SC_TECHNOLOGY_DEFAULT.
In font-missing situation, SC_TECHNOLOGY_DIRECTWRITE can show more fonts.

Florian Balmer wrote (in e-mail)...

> Notepad2 5.0.26-beta4 makes use of SC_TECHNOLOGY_DIRECTWRITE [0],
> which seems to perform better font linking than the traditional
> SC_TECHNOLOGY_DEFAULT mode, and may thus fix some GDI quirks? The same
> problem seems to appear in Notepad2 5.0.26-beta4 if DirectWrite is
> disabled [1].
> 
> [0] http://www.scintilla.org/ScintillaDoc.html#SCI_SETTECHNOLOGY
> [1] http://www.flos-freeware.ch/development-releases/notepad2-FAQs.html#d2d-rendering
> 
> Best wishes, Florian.
