### PR TITLE
Add Rust syntax highlighting

### DIFF
--- a/build/makefile.deps.mak
+++ b/build/makefile.deps.mak
@@ -56,6 +56,7 @@ $(SCI_LEX_OBJDIR)\LexPowerShell.obj: $(SCI_LEX)\LexPowerShell.cxx $(LEX_HEADERS)
 $(SCI_LEX_OBJDIR)\LexProps.obj: $(SCI_LEX)\LexProps.cxx $(LEX_HEADERS)
 $(SCI_LEX_OBJDIR)\LexPython.obj: $(SCI_LEX)\LexPython.cxx $(LEX_HEADERS)
 $(SCI_LEX_OBJDIR)\LexRuby.obj: $(SCI_LEX)\LexRuby.cxx $(LEX_HEADERS)
+$(SCI_LEX_OBJDIR)\LexRust.obj: $(SCI_LEX)\LexRust.cxx $(LEX_HEADERS)
 $(SCI_LEX_OBJDIR)\LexSQL.obj: $(SCI_LEX)\LexSQL.cxx $(LEX_HEADERS) $(SCI_LIB)\OptionSet.h
 $(SCI_LEX_OBJDIR)\LexTCL.obj: $(SCI_LEX)\LexTCL.cxx $(LEX_HEADERS)
 $(SCI_LEX_OBJDIR)\LexVB.obj: $(SCI_LEX)\LexVB.cxx $(LEX_HEADERS)

--- a/build/makefile.mak
+++ b/build/makefile.mak
@@ -150,6 +150,7 @@ SCI_LEX_OBJ = \
     $(SCI_LEX_OBJDIR)\LexProps.obj \
     $(SCI_LEX_OBJDIR)\LexPython.obj \
     $(SCI_LEX_OBJDIR)\LexRuby.obj \
+    $(SCI_LEX_OBJDIR)\LexRust.obj \
     $(SCI_LEX_OBJDIR)\LexSQL.obj \
     $(SCI_LEX_OBJDIR)\LexTCL.obj \
     $(SCI_LEX_OBJDIR)\LexVB.obj \

--- a/lexlink.js
+++ b/lexlink.js
@@ -30,6 +30,7 @@
     "lmProps",
     "lmPython",
     "lmRuby",
+    "lmRust",
     "lmSQL",
     "lmTCL",
     "lmVB",

--- a/scintilla/Scintilla.vcxproj
+++ b/scintilla/Scintilla.vcxproj
@@ -185,6 +185,7 @@
     <ClCompile Include="lexers\LexProps.cxx" />
     <ClCompile Include="lexers\LexPython.cxx" />
     <ClCompile Include="lexers\LexRuby.cxx" />
+    <ClCompile Include="lexers\LexRust.cxx" />
     <ClCompile Include="lexers\LexSQL.cxx" />
     <ClCompile Include="lexers\LexTCL.cxx" />
     <ClCompile Include="lexers\LexVB.cxx" />

--- a/scintilla/Scintilla.vcxproj.filters
+++ b/scintilla/Scintilla.vcxproj.filters
@@ -99,6 +99,9 @@
     <ClCompile Include="lexers\LexRuby.cxx">
       <Filter>lexers</Filter>
     </ClCompile>
+    <ClCompile Include="lexers\LexRust.cxx">
+      <Filter>lexers</Filter>
+    </ClCompile>
     <ClCompile Include="lexers\LexSQL.cxx">
       <Filter>lexers</Filter>
     </ClCompile>

--- a/scintilla/src/Catalogue.cxx
+++ b/scintilla/src/Catalogue.cxx
@@ -169,7 +169,7 @@ int Scintilla_LinkLexers() {
 	//LINK_LEXER(lmREBOL);
 	//LINK_LEXER(lmRegistry);
 	LINK_LEXER(lmRuby);
-	//LINK_LEXER(lmRust);
+	LINK_LEXER(lmRust);
 	//LINK_LEXER(lmScriptol);
 	//LINK_LEXER(lmSmalltalk);
 	//LINK_LEXER(lmSML);

--- a/src/Notepad2.c
+++ b/src/Notepad2.c
@@ -3388,6 +3388,7 @@ LRESULT MsgCommand(HWND hwnd,WPARAM wParam,LPARAM lParam)
         case SCLEX_XML:
         case SCLEX_CPP:
         case SCLEX_PASCAL:
+        case SCLEX_RUST:
           BeginWaitCursor();
           EditToggleLineComments(hwndEdit,L"//",FALSE);
           EndWaitCursor();
@@ -6248,7 +6249,7 @@ void ParseCommandLine()
             LocalFree(lpSchemeArg);
             lpSchemeArg = NULL;
           }
-          iInitialLexer = 34;
+          iInitialLexer = 35;
           flagLexerSpecified = 1;
           break;
 
@@ -6257,7 +6258,7 @@ void ParseCommandLine()
             LocalFree(lpSchemeArg);
             lpSchemeArg = NULL;
           }
-          iInitialLexer = 35;
+          iInitialLexer = 36;
           flagLexerSpecified = 1;
           break;
 

--- a/src/Styles.c
+++ b/src/Styles.c
@@ -1274,6 +1274,29 @@ EDITLEXER lexRUBY = { SCLEX_RUBY, 63304, L"Ruby Script", L"rb; ruby; rbw; rake; 
                     { -1, 00000, L"", L"", L"" } } };
 
 
+KEYWORDLIST KeyWords_RUST = {
+"as break crate else enum extern false fn for if impl in let loop match mod move mut "
+"pub ref return static self Self struct super true trait type unsafe use virtual "
+"while continue box const where proc alignof become offsetof priv pure sizeof "
+"typeof unsized yield do abstract final override macro",
+"", "", "", "", "", "", "", "" };
+
+EDITLEXER lexRUST = { SCLEX_RUST, 63363, L"Rust Source Code", L"rs", L"", &KeyWords_RUST, {
+                    { STYLE_DEFAULT, 63126, L"Default", L"", L"" },
+                    //{ SCE_P_DEFAULT, L"Default", L"", L"" },
+                    { MULTI_STYLE(SCE_RUST_COMMENTLINE,SCE_RUST_COMMENTBLOCK,SCE_P_COMMENTLINE,SCE_P_COMMENTBLOCK), 63127, L"Comment", L"fore:#008000", L"" },
+                    { MULTI_STYLE(SCE_RUST_COMMENTLINEDOC,SCE_RUST_COMMENTBLOCKDOC,0,0), 63223, L"Doc Comment", L"fore:#008000", L"" },
+                    { SCE_RUST_WORD, 63128, L"Keyword", L"fore:#00007F", L"" },
+                    { SCE_RUST_IDENTIFIER, 63129, L"Identifier", L"", L"" },
+                    { SCE_RUST_NUMBER, 63130, L"Number", L"fore:#008080", L"" },
+                    { SCE_RUST_OPERATOR, 63132, L"Operator", L"", L"" },
+                    { MULTI_STYLE(SCE_RUST_STRING,SCE_RUST_STRINGR,SCE_RUST_BYTESTRING,SCE_RUST_BYTESTRINGR), 63131, L"String", L"fore:#FF8000", L"" },
+                    { MULTI_STYLE(SCE_RUST_CHARACTER,SCE_RUST_BYTECHARACTER,0,0), 63135, L"Character", L"fore:#FF8000", L"" },
+                    { SCE_RUST_LIFETIME, 63316, L"Lifetime", L"fore:#C0A030", L"" },
+                    { SCE_RUST_MACRO, 63133, L"Macro", L"fore:#0000FF", L"" },
+                    { -1, 00000, L"", L"", L"" } } };
+
+
 KEYWORDLIST KeyWords_LUA = {
 "and break do else elseif end false for function goto if "
 "in local nil not or repeat return then true until while",
@@ -2485,6 +2508,7 @@ PEDITLEXER pLexArray[NUMLEXERS] =
   &lexPY,
   &lexRC,
   &lexRUBY,
+  &lexRUST,
   &lexBASH,
   &lexSQL,
   &lexTCL,

--- a/src/Styles.h
+++ b/src/Styles.h
@@ -55,7 +55,7 @@ typedef struct _editlexer
 
 
 // Number of Lexers in pLexArray
-#define NUMLEXERS 38
+#define NUMLEXERS 39
 
 
 void   Style_Load();


### PR DESCRIPTION
There's a slight bug with my edit: in the Customize Schemes dialog, the styles for Rust's doc comments and characters are labeled as Here-docs and Regexes, respectively.