### PR TITLE
RelaunchElevated will always launch a process with a visible window

### DIFF
--- a/src/Notepad2.c
+++ b/src/Notepad2.c
@@ -7602,7 +7602,7 @@ BOOL RelaunchElevated() {
       sei.lpFile = lpArg1;
       sei.lpParameters = lpArg2;
       sei.lpDirectory = g_wchWorkingDirectory;
-      sei.nShow = si.wShowWindow;
+      sei.nShow = si.wShowWindow ? si.wShowWindow : SW_SHOWNORMAL;
 
       ShellExecuteEx(&sei);
     }


### PR DESCRIPTION
I stumbled upon an issue that drove me bit nuts over the weekend: if I called RelaunchElevated (by passing `/u` or manually), while launching from Visual Studio (with or without a debugger), the child process launched, but it didn't have any visible windows!
Upon further investigation I found that the value of `STARTUPINFO.wShowWindow` was 0 for some reason, when running from VS (it corresponds to SW_HIDE). When launched from a cmd shell it had a value 1.
Having no idea why this happens, I asked this question on StackOverflow https://stackoverflow.com/questions/36953886/startupinfo-wshowwindow-is-0-when-running-from-visual-studio

In the meantime, here's a fix that will pass `SW_SHOWNORMAL` to the child process, making sure its window is always visible.