### PR TITLE
Restart Notepad2 as Administrator, keeping the changes, when unable to save file

### DIFF
--- a/src/Helpers.c
+++ b/src/Helpers.c
@@ -1656,7 +1656,7 @@ BOOL MRU_AddFile(LPMRULIST pmru,LPCWSTR pszFile,BOOL bRelativePath,BOOL bUnexpan
 
   int i;
   for (i = 0; i < pmru->iSize; i++) {
-    if (lstrcmpi(pmru->pszItems[i],pszFile) == 0) {
+    if (!pmru->pszItems[i] || lstrcmpi(pmru->pszItems[i],pszFile) == 0) {
       LocalFree(pmru->pszItems[i]);
       break;
     }

--- a/src/Notepad2.c
+++ b/src/Notepad2.c
@@ -883,6 +883,8 @@ HWND InitInstance(HINSTANCE hInstance,LPSTR pszCmdLine,int nCmdShow)
       if (bOpened = FileLoad(FALSE, FALSE, FALSE, FALSE, lpFileToOpen)) {
         if (flagBufferFile) {
           lstrcpy(szCurFile, lpFileArg);
+          if (!flagLexerSpecified)
+            Style_SetLexerFromFile(hwndEdit, szCurFile);
           bModified = TRUE;
           SetWindowTitle(hwndMain, uidsAppTitle, fIsElevated, IDS_UNTITLED, lpFileArg,
             iPathNameFormat, bModified, IDS_READONLY, bReadOnly, szTitleExcerpt);
@@ -7154,11 +7156,10 @@ BOOL FileSave(BOOL bSaveAlways,BOOL bAsk,BOOL bSaveAs,BOOL bSaveCopy)
             ExtractFirstArgument(lpCmdLine, lpExe, lpArgs);
             
             wsprintf(szArguments, L"/buffer %s %s", szTempFileName, lpArgs);
-            if (szCurFile) 
+            if (lstrlen(tchFile))
             {
-              if (!StrStr(szArguments, szCurFile)) {
-                PathQuoteSpaces(szCurFile);
-                wsprintf(szArguments, L"%s %s", szArguments, szCurFile);
+              if (!StrStrI(szArguments, tchFile)) {
+                wsprintf(szArguments, L"%s %s", szArguments, tchFile);
               }
             }
 
@@ -7632,7 +7633,7 @@ BOOL RelaunchMultiInst() {
 //  RelaunchElevated()
 //
 //
-BOOL RelaunchElevated(LPCWSTR lpArgs) {
+BOOL RelaunchElevated(LPWSTR lpArgs) {
 
   if (!IsVista() || fIsElevated || !flagRelaunchElevated || flagDisplayHelp)
     return(FALSE);

--- a/src/Notepad2.c
+++ b/src/Notepad2.c
@@ -94,6 +94,7 @@ TBBUTTON  tbbMainWnd[] = { {0,IDT_FILE_NEW,TBSTATE_ENABLED,TBSTYLE_BUTTON,0,0},
 
 WCHAR      szIniFile[MAX_PATH] = L"";
 WCHAR      szIniFile2[MAX_PATH] = L"";
+WCHAR      szBufferFile[MAX_PATH] = L"";
 BOOL      bSaveSettings;
 BOOL      bSaveRecentFiles;
 BOOL      bSaveFindReplace;
@@ -373,6 +374,7 @@ int flagQuietCreate        = 0;
 int flagUseSystemMRU       = 0;
 int flagRelaunchElevated   = 0;
 int flagDisplayHelp        = 0;
+int flagBufferFile         = 0;
 
 
 
@@ -875,8 +877,16 @@ HWND InitInstance(HINSTANCE hInstance,LPSTR pszCmdLine,int nCmdShow)
       if (OpenFileDlg(hwndMain,tchFile,COUNTOF(tchFile),lpFileArg))
         bOpened = FileLoad(FALSE,FALSE,FALSE,FALSE,tchFile);
     }
-    else {
-      if (bOpened = FileLoad(FALSE,FALSE,FALSE,FALSE,lpFileArg)) {
+    else
+    {
+      LPCWSTR lpFileToOpen = flagBufferFile ? szBufferFile : lpFileArg;
+      if (bOpened = FileLoad(FALSE, FALSE, FALSE, FALSE, lpFileToOpen)) {
+        if (flagBufferFile) {
+          lstrcpy(szCurFile, lpFileArg);
+          bModified = TRUE;
+          SetWindowTitle(hwndMain, uidsAppTitle, fIsElevated, IDS_UNTITLED, lpFileArg,
+            iPathNameFormat, bModified, IDS_READONLY, bReadOnly, szTitleExcerpt);
+        }
         if (flagJumpTo) { // Jump to position
           EditJumpTo(hwndEdit,iInitialLine,iInitialColumn);
           EditEnsureSelectionVisible(hwndEdit);
@@ -6030,6 +6040,14 @@ void ParseCommandLine()
           flagUseSystemMRU = 2;
         else
           flagUseSystemMRU = 1;
+      }
+      else if (StrCmpNI(lp1,L"buffer",CSTRLEN(L"buffer")) == 0) {
+        if (ExtractFirstArgument(lp2, lp1, lp2)) {
+          StrCpyN(szBufferFile, lp1, COUNTOF(szBufferFile));
+          TrimString(szBufferFile);
+          PathUnquoteSpaces(szBufferFile);
+          flagBufferFile = 1;
+        }
       }
 
       else switch (*CharUpper(lp1))

--- a/src/Notepad2.c
+++ b/src/Notepad2.c
@@ -641,7 +641,7 @@ int WINAPI WinMain(HINSTANCE hInstance,HINSTANCE hPrevInst,LPSTR lpCmdLine,int n
     StrCat(wchWndClass,L"B");
 
   // Relaunch with elevated privileges
-  if (RelaunchElevated())
+  if (RelaunchElevated(NULL))
     return(0);
 
   // Try to run multiple instances
@@ -7134,11 +7134,53 @@ BOOL FileSave(BOOL bSaveAlways,BOOL bAsk,BOOL bSaveAs,BOOL bSaveCopy)
     if (lstrlen(szCurFile) != 0)
       lstrcpy(tchFile,szCurFile);
 
-    SetWindowTitle(hwndMain,uidsAppTitle,fIsElevated,IDS_UNTITLED,szCurFile,
-      iPathNameFormat,bModified || iEncoding != iOriginalEncoding,
-      IDS_READONLY,bReadOnly,szTitleExcerpt);
+    if (!fIsElevated && dwLastIOError == ERROR_ACCESS_DENIED)
+    {
+      if (IDYES == MsgBox(MBYESNOWARN, IDS_ERR_ACCESSDENIED, tchFile))
+      {
+        WCHAR lpTempPathBuffer[MAX_PATH];
+        WCHAR szTempFileName[MAX_PATH];
 
-    MsgBox(MBWARN,IDS_ERR_SAVEFILE,tchFile);
+        if (GetTempPath(MAX_PATH, lpTempPathBuffer) &&
+            GetTempFileName(lpTempPathBuffer, TEXT("N2"), 0, szTempFileName))
+        {
+          if (FileIO(FALSE, szTempFileName, FALSE, &iEncoding, &iEOLMode, NULL, NULL, &bCancelDataLoss, TRUE)) 
+          {
+            WCHAR szArguments[2 * MAX_PATH + 64] = L"";
+            LPWSTR lpCmdLine = GetCommandLine();
+            LPWSTR lpExe = LocalAlloc(LPTR, sizeof(WCHAR)*(lstrlen(lpCmdLine) + 1));
+            LPWSTR lpArgs = LocalAlloc(LPTR, sizeof(WCHAR)*(lstrlen(lpCmdLine) + 1));
+
+            ExtractFirstArgument(lpCmdLine, lpExe, lpArgs);
+            
+            wsprintf(szArguments, L"/buffer %s %s", szTempFileName, lpArgs);
+            if (szCurFile) 
+            {
+              if (!StrStr(szArguments, szCurFile)) {
+                PathQuoteSpaces(szCurFile);
+                wsprintf(szArguments, L"%s %s", szArguments, szCurFile);
+              }
+            }
+
+            flagRelaunchElevated = 1;
+            if (RelaunchElevated(szArguments)) 
+            {
+              LocalFree(lpExe);
+              LocalFree(lpArgs);
+              exit(0);
+            }
+          }
+        }
+      }
+    } 
+    else
+    {
+      SetWindowTitle(hwndMain,uidsAppTitle,fIsElevated,IDS_UNTITLED,szCurFile,
+        iPathNameFormat,bModified || iEncoding != iOriginalEncoding,
+        IDS_READONLY,bReadOnly,szTitleExcerpt);
+
+      MsgBox(MBWARN,IDS_ERR_SAVEFILE,tchFile);
+    }
   }
 
   return(fSuccess);
@@ -7590,43 +7632,50 @@ BOOL RelaunchMultiInst() {
 //  RelaunchElevated()
 //
 //
-BOOL RelaunchElevated() {
+BOOL RelaunchElevated(LPCWSTR lpArgs) {
 
   if (!IsVista() || fIsElevated || !flagRelaunchElevated || flagDisplayHelp)
     return(FALSE);
 
   else {
 
-    LPWSTR lpCmdLine;
-    LPWSTR lpArg1, lpArg2;
+    LPWSTR lpCmdLine, lpExe;
     STARTUPINFO si;
     SHELLEXECUTEINFO sei;
+    BOOL bShouldFree = FALSE;
 
     si.cb = sizeof(STARTUPINFO);
     GetStartupInfo(&si);
 
     lpCmdLine = GetCommandLine();
-    lpArg1 = LocalAlloc(LPTR,sizeof(WCHAR)*(lstrlen(lpCmdLine) + 1));
-    lpArg2 = LocalAlloc(LPTR,sizeof(WCHAR)*(lstrlen(lpCmdLine) + 1));
-    ExtractFirstArgument(lpCmdLine,lpArg1,lpArg2);
+    lpExe = LocalAlloc(LPTR, sizeof(WCHAR)*(lstrlen(lpCmdLine) + 1));
+    if (!lpArgs) {
+      lpArgs = LocalAlloc(LPTR,sizeof(WCHAR)*(lstrlen(lpCmdLine) + 1));
+      ExtractFirstArgument(lpCmdLine, lpExe, lpArgs);
+      bShouldFree = TRUE;
+    } 
+    else {
+      ExtractFirstArgument(lpCmdLine, lpExe, NULL);
+    }
 
-    if (lstrlen(lpArg1)) {
+    if (lstrlen(lpArgs)) {
 
       ZeroMemory(&sei,sizeof(SHELLEXECUTEINFO));
       sei.cbSize = sizeof(SHELLEXECUTEINFO);
       sei.fMask = SEE_MASK_FLAG_NO_UI | /*SEE_MASK_NOASYNC*/0x00000100 | /*SEE_MASK_NOZONECHECKS*/0x00800000;
       sei.hwnd = GetForegroundWindow();
       sei.lpVerb = L"runas";
-      sei.lpFile = lpArg1;
-      sei.lpParameters = lpArg2;
+      sei.lpFile = lpExe;
+      sei.lpParameters = lpArgs;
       sei.lpDirectory = g_wchWorkingDirectory;
-      sei.nShow = si.wShowWindow;
+      sei.nShow = si.wShowWindow ? si.wShowWindow : SW_SHOWNORMAL;
 
       ShellExecuteEx(&sei);
     }
 
-    LocalFree(lpArg1);
-    LocalFree(lpArg2);
+    if (bShouldFree)
+      LocalFree(lpArgs);
+    LocalFree(lpExe);
 
     return(TRUE);
   }

--- a/src/Notepad2.h
+++ b/src/Notepad2.h
@@ -100,7 +100,7 @@ BOOL InitApplication(HINSTANCE);
 HWND InitInstance(HINSTANCE,LPSTR,int);
 BOOL ActivatePrevInst();
 BOOL RelaunchMultiInst();
-BOOL RelaunchElevated(LPCWSTR);
+BOOL RelaunchElevated(LPWSTR);
 void SnapToDefaultPos(HWND);
 void ShowNotifyIcon(HWND,BOOL);
 void SetNotifyIconTitle(HWND);

--- a/src/Notepad2.h
+++ b/src/Notepad2.h
@@ -100,7 +100,7 @@ BOOL InitApplication(HINSTANCE);
 HWND InitInstance(HINSTANCE,LPSTR,int);
 BOOL ActivatePrevInst();
 BOOL RelaunchMultiInst();
-BOOL RelaunchElevated();
+BOOL RelaunchElevated(LPCWSTR);
 void SnapToDefaultPos(HWND);
 void ShowNotifyIcon(HWND,BOOL);
 void SetNotifyIconTitle(HWND);

--- a/src/Notepad2.rc
+++ b/src/Notepad2.rc
@@ -1576,6 +1576,7 @@ BEGIN
     IDS_ASK_ENCODING2       "You are about to change the encoding of an empty file from ANSI to non-ANSI. Note that this will clear the undo history, as it can't be synchronized with the new encoding. Continue?"
     IDS_ERR_ENCODINGNA      "Code page conversion tables for the selected encoding are not available on your system."
     IDS_ERR_UNICODE         "Error converting this Unicode file.\nData will be lost if the file is saved!"
+    IDS_ERR_ACCESSDENIED    "The file ""%s"" cannot be saved and may be protected.\n\nDo you want to launch Notepad2-mod as Administrator?"
 END
 
 STRINGTABLE

--- a/src/resource.h
+++ b/src/resource.h
@@ -423,6 +423,7 @@
 #define IDS_WRITEINI_FAIL               50038
 #define IDS_SETTINGSNOTSAVED            50039
 #define IDS_EXPORT_FAIL                 50040
+#define IDS_ERR_ACCESSDENIED            50041
 #define IDS_CMDLINEHELP                 60000
 
 // Next default values for new objects


### PR DESCRIPTION
Fixes #8

This PR adds a much-needed feature to restart Notepad2-mod as an Administrator, when saving a file fails, similarly to how other editors, such as Notepad++ behave.

![animation](https://cloud.githubusercontent.com/assets/601206/14937834/0502fa86-0f1c-11e6-9ea8-f2650b3531e1.gif)

The main issue was - how to retain the changes between restarts. I solved it by saving a temporary file on disk, and passing it as a new parameter to Notepad2-mod, allowing to load the original file, but replace its text with the contents of the temp file.
The new parameter is called `buffer`, and it will set the text of Notepad2 to the contents of a file passed as parameter, e.g.:
`notepad2.exe /buffer "C:\temp\N2ffff.tmp" "C:\Program Files (x86)\original.txt"`

This allows restarting Notepad2-mod (by leveraging the `RelaunchElevated` function, passing it the additional `buffer` parameter)
