### PR TITLE
Add JavaScript keyword "let"

### DIFF
--- a/src/Styles.c
+++ b/src/Styles.c
@@ -614,7 +614,7 @@ EDITLEXER lexVB = { SCLEX_VB, 63009, L"Visual Basic", L"vb; bas; frm; cls; ctl; 
 KEYWORDLIST KeyWords_JS = {
 "abstract boolean break byte case catch char class const continue debugger default delete do "
 "double else enum export extends false final finally float for function goto if implements "
-"import in instanceof int interface long native new null package private protected public "
+"import in instanceof int interface let long native new null package private protected public "
 "return short static super switch synchronized this throw throws transient true try typeof var "
 "void volatile while with",
 "", "", "", "", "", "", "", "" };


### PR DESCRIPTION
This keyword was added in ES6/ES2015.

`const` was also new in ES6, but for some reason it was already listed in Notepad2, dating all the way back to the initial SVN import in 2010.