### PR TITLE
Change shortcuts for line comment, stream comment, reset zoom and transparent mode

### DIFF
--- a/src/Notepad2.rc
+++ b/src/Notepad2.rc
@@ -214,8 +214,8 @@ BEGIN
         END
         POPUP "Spec&ial"
         BEGIN
-            MENUITEM "Line Comment (&Toggle)\tCtrl+Q", IDM_EDIT_LINECOMMENT
-            MENUITEM "Stream &Comment\tCtrl+Shift+Q", IDM_EDIT_STREAMCOMMENT
+            MENUITEM "Line Comment (&Toggle)\tCtrl+/", IDM_EDIT_LINECOMMENT
+            MENUITEM "Stream &Comment\tCtrl+Shift+/", IDM_EDIT_STREAMCOMMENT
             MENUITEM SEPARATOR
             MENUITEM "URL &Encode\tCtrl+Shift+E",   IDM_EDIT_URLENCODE
             MENUITEM "URL &Decode\tCtrl+Shift+R",   IDM_EDIT_URLDECODE
@@ -302,7 +302,7 @@ BEGIN
         MENUITEM SEPARATOR
         MENUITEM "Zoom &In\tCtrl++",            IDM_VIEW_ZOOMIN
         MENUITEM "Zoom &Out\tCtrl+-",           IDM_VIEW_ZOOMOUT
-        MENUITEM "Reset &Zoom\tCtrl+/",         IDM_VIEW_RESETZOOM
+        MENUITEM "Reset &Zoom\tCtrl+0",         IDM_VIEW_RESETZOOM
     END
     POPUP "&Settings"
     BEGIN
@@ -319,7 +319,7 @@ BEGIN
         MENUITEM "Sticky Window &Position",     IDM_VIEW_STICKYWINPOS
         MENUITEM "&Always On Top\tAlt+T",       IDM_VIEW_ALWAYSONTOP
         MENUITEM "Minimi&ze To Tray",           IDM_VIEW_MINTOTRAY
-        MENUITEM "Transparent &Mode\tCtrl+0",   IDM_VIEW_TRANSPARENT
+        MENUITEM "Transparent &Mode",           IDM_VIEW_TRANSPARENT
         MENUITEM SEPARATOR
         MENUITEM "Single &File Instance",       IDM_VIEW_SINGLEFILEINSTANCE
         MENUITEM "File &Change Notification...\tAlt+F5",
@@ -392,7 +392,7 @@ END
 
 IDR_MAINWND ACCELERATORS
 BEGIN
-    "0",            IDM_VIEW_TRANSPARENT,   VIRTKEY, CONTROL, NOINVERT
+    "0",            IDM_VIEW_RESETZOOM,     VIRTKEY, CONTROL, NOINVERT
     "0",            IDM_FILE_NEWWINDOW2,    VIRTKEY, ALT, NOINVERT
     "0",            IDM_VIEW_WORDWRAPSYMBOLS, VIRTKEY, SHIFT, CONTROL,
                                                     NOINVERT
@@ -479,10 +479,7 @@ BEGIN
     "P",            IDM_EDIT_COMPRESSWS,    VIRTKEY, ALT, NOINVERT
     "P",            CMD_DEFAULTWINPOS,      VIRTKEY, SHIFT, CONTROL,
                                                     NOINVERT
-    "Q",            IDM_EDIT_LINECOMMENT,   VIRTKEY, CONTROL, NOINVERT
     "Q",            IDM_EDIT_ENCLOSESELECTION, VIRTKEY, ALT, NOINVERT
-    "Q",            IDM_EDIT_STREAMCOMMENT, VIRTKEY, SHIFT, CONTROL,
-                                                    NOINVERT
     "R",            IDM_FILE_RUN,           VIRTKEY, CONTROL, NOINVERT
     "R",            IDM_EDIT_REMOVEBLANKLINES, VIRTKEY, ALT, NOINVERT
     "R",            IDM_EDIT_UNESCAPECCHARS, VIRTKEY, CONTROL, ALT, NOINVERT
@@ -516,7 +513,9 @@ BEGIN
     VK_DELETE,      IDM_EDIT_CUT,           VIRTKEY, SHIFT, NOINVERT
     VK_DELETE,      IDM_EDIT_DELETELINERIGHT, VIRTKEY, SHIFT, CONTROL,
                                                     NOINVERT
-    VK_DIVIDE,      IDM_VIEW_RESETZOOM,     VIRTKEY, CONTROL, NOINVERT
+    VK_DIVIDE,      IDM_EDIT_LINECOMMENT,   VIRTKEY, CONTROL, NOINVERT
+    VK_DIVIDE,      IDM_EDIT_STREAMCOMMENT, VIRTKEY, SHIFT, CONTROL,
+                                                    NOINVERT
     VK_DOWN,        IDM_EDIT_MOVELINEDOWN,  VIRTKEY, SHIFT, CONTROL,
                                                     NOINVERT
     VK_ESCAPE,      CMD_ESCAPE,             VIRTKEY, NOINVERT
@@ -567,7 +566,9 @@ BEGIN
     VK_F9,          CMD_COPYPATHNAME,       VIRTKEY, SHIFT, NOINVERT
     VK_F9,          IDM_EDIT_INSERT_PATHNAME, VIRTKEY, SHIFT, CONTROL,
                                                     NOINVERT
-    VK_OEM_2,       IDM_VIEW_RESETZOOM,     VIRTKEY, CONTROL, NOINVERT
+    VK_OEM_2,       IDM_EDIT_LINECOMMENT,   VIRTKEY, CONTROL, NOINVERT
+    VK_OEM_2,       IDM_EDIT_STREAMCOMMENT, VIRTKEY, SHIFT, CONTROL,
+                                                    NOINVERT
     VK_OEM_COMMA,   CMD_JUMP2SELSTART,      VIRTKEY, CONTROL, NOINVERT
     VK_OEM_MINUS,   IDM_VIEW_ZOOMOUT,       VIRTKEY, CONTROL, NOINVERT
     VK_OEM_MINUS,   CMD_DECREASENUM,        VIRTKEY, CONTROL, ALT, NOINVERT


### PR DESCRIPTION
Change shortcuts for the following actions:

- Line Comment : **Ctrl+Q** change to **Ctrl+/**
- Stream Comment : **Ctrl+Shift+Q** change to **Ctrl+Shift+/**
- Reset Zoom: **Ctrl+/** change to **Ctrl+0**
- Transparent Mode: **Ctrl+0** change to nothing (I guess that nobody uses this action).

I believe that new shortcuts are more convenient and more widely used, aren't they?