### PR TITLE
Add hidden features to program menu, fix reload as UTF-8 bug

### DIFF
--- a/src/Dialogs.c
+++ b/src/Dialogs.c
@@ -117,7 +117,7 @@ int MsgBox(int iType,UINT uIdMsg,...)
 //
 //  DisplayCmdLineHelp()
 //
-void DisplayCmdLineHelp()
+void DisplayCmdLineHelp(HWND hwnd)
 {
   MSGBOXPARAMS mbp;
 
@@ -128,7 +128,7 @@ void DisplayCmdLineHelp()
   GetString(IDS_CMDLINEHELP,szText,COUNTOF(szText));
 
   mbp.cbSize = sizeof(MSGBOXPARAMS);
-  mbp.hwndOwner = NULL;
+  mbp.hwndOwner = hwnd;
   mbp.hInstance = g_hInstance;
   mbp.lpszText = szText;
   mbp.lpszCaption = szTitle;

--- a/src/Dialogs.h
+++ b/src/Dialogs.h
@@ -27,7 +27,7 @@
 #define MBOKCANCEL     8
 
 int  MsgBox(int,UINT,...);
-void DisplayCmdLineHelp();
+void DisplayCmdLineHelp(HWND hwnd);
 BOOL GetDirectory(HWND,int,LPWSTR,LPCWSTR,BOOL);
 INT_PTR CALLBACK AboutDlgProc(HWND,UINT,WPARAM,LPARAM);
 void RunDlg(HWND,LPCWSTR);

--- a/src/Edit.c
+++ b/src/Edit.c
@@ -1338,12 +1338,14 @@ BOOL EditLoadFile(
             ((IsUTF8Signature(lpData) ||
               FileVars_IsUTF8(&fvCurFile) ||
               (iSrcEncoding == CPI_UTF8 || iSrcEncoding == CPI_UTF8SIGN) ||
+              // from menu "Reload As UTF-8"
+              (!bPreferOEM && bLoadASCIIasUTF8) ||
               (IsUTF8(lpData,cbData) &&
               (((UTF8_mbslen_bytes(UTF8StringStart(lpData)) - 1 !=
                 UTF8_mbslen(UTF8StringStart(lpData),IsUTF8Signature(lpData) ? cbData-3 : cbData)) ||
                 (!bPreferOEM && (
-                mEncoding[_iDefaultEncoding].uFlags & NCP_UTF8 ||
-                bLoadASCIIasUTF8 )) ))))) && !(FileVars_IsNonUTF8(&fvCurFile) &&
+                mEncoding[_iDefaultEncoding].uFlags & NCP_UTF8
+                )) ))))) && !(FileVars_IsNonUTF8(&fvCurFile) &&
                   (iSrcEncoding != CPI_UTF8 && iSrcEncoding != CPI_UTF8SIGN)))
     {
       SendMessage(hwnd,SCI_SETCODEPAGE,SC_CP_UTF8,0);

--- a/src/Notepad2.c
+++ b/src/Notepad2.c
@@ -628,7 +628,7 @@ int WINAPI WinMain(HINSTANCE hInstance,HINSTANCE hPrevInst,LPSTR lpCmdLine,int n
 
   // Command Line Help Dialog
   if (flagDisplayHelp) {
-    DisplayCmdLineHelp();
+    DisplayCmdLineHelp(NULL);
     return(0);
   }
 
@@ -2054,6 +2054,11 @@ void MsgInitMenu(HWND hwnd,WPARAM wParam,LPARAM lParam)
 
   i = lstrlen(szCurFile);
   EnableCmd(hmenu,IDM_FILE_REVERT,i);
+  EnableCmd(hmenu, CMD_RELOADASCIIASUTF8, i);
+  EnableCmd(hmenu, CMD_RELOADANSI, i);
+  EnableCmd(hmenu, CMD_RELOADOEM, i);
+  EnableCmd(hmenu, CMD_RELOADNOFILEVARS, i);
+  EnableCmd(hmenu, CMD_RECODEDEFAULT, i);
   EnableCmd(hmenu,IDM_FILE_LAUNCH,i);
   EnableCmd(hmenu,IDM_FILE_PROPERTIES,i);
   EnableCmd(hmenu,IDM_FILE_CREATELINK,i);
@@ -2200,6 +2205,11 @@ void MsgInitMenu(HWND hwnd,WPARAM wParam,LPARAM lParam)
   EnableCmd(hmenu,BME_EDIT_BOOKMARKTOGGLE,i);
   EnableCmd(hmenu,BME_EDIT_BOOKMARKCLEAR,i);
 #endif
+  EnableCmd(hmenu, IDM_EDIT_DELETELINELEFT, i);
+  EnableCmd(hmenu, IDM_EDIT_DELETELINERIGHT, i);
+  EnableCmd(hmenu, CMD_CTRLBACK, i);
+  EnableCmd(hmenu, CMD_CTRLDEL, i);
+  EnableCmd(hmenu, CMD_TIMESTAMPS, i);
   EnableCmd(hmenu,IDM_VIEW_TOGGLEFOLDS,i && bShowCodeFolding);
   CheckCmd(hmenu,IDM_VIEW_FOLDING,bShowCodeFolding);
 
@@ -4348,6 +4358,11 @@ LRESULT MsgCommand(HWND hwnd,WPARAM wParam,LPARAM lParam)
     case IDM_HELP_ABOUT:
       ThemedDialogBox(g_hInstance,MAKEINTRESOURCE(IDD_ABOUT),
         hwnd,AboutDlgProc);
+      break;
+
+
+    case IDM_CMDLINE_HELP:
+      DisplayCmdLineHelp(hwnd);
       break;
 
 

--- a/src/Notepad2.rc
+++ b/src/Notepad2.rc
@@ -73,6 +73,14 @@ BEGIN
         MENUITEM "Save &Copy...\tCtrl+F6",      IDM_FILE_SAVECOPY
         MENUITEM "&Read Only",                  IDM_FILE_READONLY
         MENUITEM SEPARATOR
+        POPUP "&Reload"
+        BEGIN
+            MENUITEM "As UFT-&8\tShift+F8",         CMD_RELOADASCIIASUTF8
+            MENUITEM "As &ANSI\tCtrl+Shift+A",      CMD_RELOADANSI
+            MENUITEM "As &OEM\tCtrl+Shift+O",       CMD_RELOADOEM
+            MENUITEM "&No FileVars\tAlt+F8",        CMD_RELOADNOFILEVARS
+            MENUITEM "&Default\tCtrl+Alt+F",        CMD_RECODEDEFAULT
+        END
         POPUP "&Launch"
         BEGIN
             MENUITEM "&New Window\tAlt+N",          IDM_FILE_NEWWINDOW
@@ -81,6 +89,9 @@ BEGIN
             MENUITEM "Execute &Document\tCtrl+L",   IDM_FILE_LAUNCH
             MENUITEM "&Open with...\tAlt+L",        IDM_FILE_OPENWITH
             MENUITEM "&Command...\tCtrl+R",         IDM_FILE_RUN
+            MENUITEM SEPARATOR
+            MENUITEM "Web Template &1\tCtrl+Shift+1",   CMD_WEBACTION1
+            MENUITEM "Web Template &2\tCtrl+Shift+2",   CMD_WEBACTION2
         END
         MENUITEM SEPARATOR
         POPUP "&Encoding"
@@ -112,6 +123,7 @@ BEGIN
         MENUITEM "Propert&ies...",              IDM_FILE_PROPERTIES
         MENUITEM "Create &Desktop Link",        IDM_FILE_CREATELINK
         MENUITEM SEPARATOR
+        MENUITEM "Browse...\tCtrl+M",           IDM_FILE_BROWSE
         POPUP "&Favorites"
         BEGIN
             MENUITEM "&Open Favorites...\tAlt+I",   IDM_FILE_OPENFAV
@@ -157,8 +169,6 @@ BEGIN
             MENUITEM "&Indent\tTab",                IDM_EDIT_INDENT
             MENUITEM "&Unindent\tShift+Tab",        IDM_EDIT_UNINDENT
             MENUITEM SEPARATOR
-            MENUITEM "&Enclose Selection...\tAlt+Q",
-                                                    IDM_EDIT_ENCLOSESELECTION
 
             MENUITEM "&Duplicate Selection\tAlt+D", IDM_EDIT_SELECTIONDUPLICATE
 
@@ -176,10 +186,21 @@ BEGIN
             MENUITEM "Alig&n Lines...\tAlt+J",      IDM_EDIT_ALIGN
             MENUITEM "S&ort Lines...\tAlt+O",       IDM_EDIT_SORTLINES
         END
+        POPUP "&Enclose Selection"
+        BEGIN
+            MENUITEM "&With...\tAlt+Q",             IDM_EDIT_ENCLOSESELECTION
+            MENUITEM SEPARATOR
+            MENUITEM "( )\tCtrl+3",                 CMD_EMBRACE
+            MENUITEM "{ }\tCtrl+4",                 CMD_EMBRACE2
+            MENUITEM "[ ]\tCtrl+5",                 CMD_EMBRACE3
+            MENUITEM SEPARATOR
+            MENUITEM "&Single Quotes\tCtrl+1",      CMD_STRINGIFY
+            MENUITEM "&Double Quotes\tCtrl+2",      CMD_STRINGIFY2
+            MENUITEM "&Backticks\tCtrl+6",          CMD_EMBRACE4
+        END
         POPUP "C&onvert"
         BEGIN
             MENUITEM "&Uppercase\tCtrl+Shift+U",    IDM_EDIT_CONVERTUPPERCASE
-
             MENUITEM "&Lowercase\tCtrl+U",          IDM_EDIT_CONVERTLOWERCASE
 
             MENUITEM SEPARATOR
@@ -197,6 +218,8 @@ BEGIN
         END
         POPUP "I&nsert"
         BEGIN
+            MENUITEM "Complete Word\tCtrl+Enter",   IDM_EDIT_COMPLETEWORD
+            MENUITEM SEPARATOR
             MENUITEM "&HTML/XML Tag...\tAlt+X",     IDM_EDIT_INSERT_TAG
             MENUITEM SEPARATOR
             MENUITEM "&Encoding Identifier\tCtrl+F8",
@@ -237,7 +260,12 @@ BEGIN
             MENUITEM "Select To Ne&xt\tCtrl+Alt+F2",         IDM_EDIT_SELTONEXT
             MENUITEM "Select To Pre&vious\tCtrl+Alt+Shift+F2", IDM_EDIT_SELTOPREV
             MENUITEM SEPARATOR
-            MENUITEM "Complete Word\tCtrl+Enter",   IDM_EDIT_COMPLETEWORD
+            MENUITEM "Delete Line Left\tCtrl+Shift+Back",   IDM_EDIT_DELETELINELEFT
+            MENUITEM "Delete Line Right\tCtrl+Shift+Del",   IDM_EDIT_DELETELINERIGHT
+            MENUITEM "Delete Word Left\tCtrl+Back",         CMD_CTRLBACK
+            MENUITEM "Delete Word Right\tCtrl+Del",         CMD_CTRLDEL
+            MENUITEM SEPARATOR
+            MENUITEM "Update Timestamps\tShift+F5", CMD_TIMESTAMPS
         END
 #ifdef BOOKMARK_EDITION
         POPUP "Bookmarks"
@@ -350,10 +378,12 @@ BEGIN
         MENUITEM SEPARATOR
         MENUITEM "Save Settings On E&xit",      IDM_VIEW_SAVESETTINGS
         MENUITEM "Save Settings &Now\tF7",      IDM_VIEW_SAVESETTINGSNOW
+        MENUITEM "&Open Notepad2.ini\tCtrl+F7", CMD_OPENINIFILE
     END
     POPUP "&?"
     BEGIN
         MENUITEM "&About...\tF1",               IDM_HELP_ABOUT
+        MENUITEM "&Command Line Help",          IDM_CMDLINE_HELP
     END
 END
 
@@ -545,7 +575,6 @@ BEGIN
     VK_F3,          CMD_FINDPREVSEL,        VIRTKEY, SHIFT, CONTROL,
                                                     NOINVERT
     VK_F4,          IDM_EDIT_REPLACENEXT,   VIRTKEY, NOINVERT
-    VK_F4,          IDM_FILE_NEW,           VIRTKEY, CONTROL, NOINVERT
     VK_F4,          IDM_FILE_NEW,           VIRTKEY, CONTROL, NOINVERT
     VK_F5,          IDM_FILE_REVERT,        VIRTKEY, NOINVERT
     VK_F5,          IDM_EDIT_INSERT_SHORTDATE, VIRTKEY, CONTROL, NOINVERT

--- a/src/resource.h
+++ b/src/resource.h
@@ -353,6 +353,7 @@
 #define IDM_VIEW_MARKOCCURRENCES_WORD   40452
 #define IDM_VIEW_AUTOCOMPLETEWORDS      40453
 #define IDM_HELP_ABOUT                  40500
+#define IDM_CMDLINE_HELP                40501
 #define IDM_TRAY_RESTORE                40600
 #define IDM_TRAY_EXIT                   40601
 #define IDT_FILE_NEW                    40700


### PR DESCRIPTION
There are many useful hidden features in the program, which can only be accessed via command shortcuts. 
Adding these shortcuts to program menu make it easy to use, without to read the document (Notepad2.txt, Readme-mod.txt or http://www.flos-freeware.ch/notepad2.html) carefully and remember these key combinations.

Commit list:

1. Add hidden features: reload as UTF-8, ANSI or OEM; reload no FileVars; reload default; lanuch web template; file browse; enclose selection with braces, brackets, quotes or backticks; delete line left or right; delete word left or right; update timestamps; open Notepad2.ini; show command line help; to program menu.

2. fix reload as UTF-8 not work bug.